### PR TITLE
Improve environment for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Run the following command from the project root:
 When all services finish initializing successfully, you should have all you need running on the default endpoints:
 - Keycloak on http://localhost:8088/
 - FHIR Bridge on http://localhost:8888/fhir-bridge/fhir
-- FHIR Server (using HAPI FHIR JPA Server Starter) on http://localhost:8082/fhir
+- Demographics Service on http://localhost:8082/fhir
 
 **NOTE**: The Keycloak instance does not have the required configuration to immediately run this app. You will to do that manually for now.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#NUM Platform SMART On FHIR POC Client
+# NUM Platform SMART On FHIR POC Client
 
 This is a Vue.js (v2) based single page app (SPA), developed as a proof of concept client for NUM Platform's Demographic and FHIR-Bridge components
 
@@ -8,10 +8,25 @@ It is configured to support both js and typescript. Various critical URLs are in
 - Fhir Bridge URL: See REST requests to http://localhost:8888/fhir-bridge/fhir in Softmain.js
 - Demographic URL: See REST requests to http://localhost:8082/fhir/Patient in Softmain.js
 
+## Local environment
+
+You can use [Docker Compose](https://docs.docker.com/compose/) to start up a local environment with all services this project depends on.
+Run the following command from the project root:
+
+    docker-compose -f dev/docker-compose.yml up
+
+When all services finish initializing successfully, you should have all you need running on the default endpoints:
+- Keycloak on http://localhost:8088/
+- FHIR Bridge on http://localhost:8888/fhir-bridge/fhir
+- FHIR Server (using HAPI FHIR JPA Server Starter) on http://localhost:8082/fhir
+
+**NOTE**: The Keycloak instance does not have the required configuration to immediately run this app. You will to do that manually for now.
+
+## Development
+
 This project was created using Vue CLI, following the standard Vue documentation, so please see Vue.js web site for V2 to get an understanding of Vue. The contents below are created automatically by the Vue CLI and explain how to run some key commands for this app.
 
-
-## Project setup
+### Project setup
 ```
 npm install
 ```

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,0 +1,69 @@
+version: "3"
+
+services:
+  postgresql:
+    image: bitnami/postgresql:11.17.0
+    environment:
+      ALLOW_EMPTY_PASSWORD: "yes"
+      POSTGRESQL_USERNAME: bn_keycloak
+      POSTGRESQL_DATABASE: bitnami_keycloak
+
+  keycloak:
+    depends_on:
+      - postgresql
+    image: bitnami/keycloak:19.0.3
+    environment:
+      KEYCLOAK_ADMIN_USER: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    ports:
+      - "8088:8080"
+
+  ehrdb:
+    image: ehrbase/ehrbase-postgres:13.4
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      EHRBASE_USER: ehrbase
+      EHRBASE_PASSWORD: ehrbase123
+
+  ehrbase:
+    depends_on:
+      - ehrdb
+    image: ehrbase/ehrbase:0.21.1
+    environment:
+      DB_URL: jdbc:postgresql://ehrdb:5432/ehrbase
+      DB_USER: ehrbase
+      DB_PASS: ehrbase123
+      AUTH_TYPE: BASIC
+      AUTH_USER: fhir_bridge
+      AUTH_PASSWORD: fhir_bridge123
+      SYSTEM_NAME: local.ehrbase.org
+
+  fhirdb:
+    image: bitnami/postgresql:14.5.0
+    environment:
+      POSTGRES_USERNAME: fhir_bridge
+      POSTGRES_PASSWORD: fhir_bridge123
+      POSTGRESQL_DATABASE: fhir_bridge
+
+  fhir-bridge:
+    depends_on:
+      - keycloak
+      - ehrbase
+      - fhirdb
+    image: ehrbase/fhir-bridge:1.5.5
+    environment:
+      FHIRBRIDGE_OPENEHR_URL: http://ehrbase:8080/ehrbase/
+      FHIRBRIDGE_OPENEHR_SECURITY_USER_NAME: fhir_bridge
+      FHIRBRIDGE_OPENEHR_SECURITY_USER_PASSWORD: fhir_bridge123
+      SPRING_DATASOURCE_URL: jdbc:postgresql://fhirdb:5432/fhir_bridge
+      SPRING_DATASOURCE_USERNAME: fhir_bridge
+      SPRING_DATASOURCE_PASSWORD: fhir_bridge123
+      SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT: org.hibernate.dialect.PostgreSQL95Dialect
+    ports:
+      - "8888:8888"
+
+  demographics:
+    image: hapiproject/hapi:v6.1.0
+    ports:
+      - "8082:8080"

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -40,11 +40,10 @@ services:
       SYSTEM_NAME: local.ehrbase.org
 
   fhirdb:
-    image: bitnami/postgresql:14.5.0
+    image: postgres:13.4
     environment:
-      POSTGRES_USERNAME: fhir_bridge
+      POSTGRES_USER: fhir_bridge
       POSTGRES_PASSWORD: fhir_bridge123
-      POSTGRESQL_DATABASE: fhir_bridge
 
   fhir-bridge:
     depends_on:
@@ -63,7 +62,21 @@ services:
     ports:
       - "8888:8888"
 
+  demographicsdb:
+    image: postgres:13.4
+    environment:
+      POSTGRES_USER: demographic
+      POSTGRES_PASSWORD: demographic123
+
   demographics:
-    image: hapiproject/hapi:v6.1.0
+    depends_on:
+      - demographicsdb
+    image: numresearchdataplatform/demographics-service:develop
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://demographicsdb:5432/demographic
+      SPRING_DATASOURCE_USERNAME: demographic
+      SPRING_DATASOURCE_PASSWORD: demographic123
+      KEYCLOAK_URL: http://keycloak:8080
+      SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI: http://keycloak:8080/realms/master/protocol/openid-connect/certs
     ports:
       - "8082:8080"


### PR DESCRIPTION
These changes introduce a new `docker-compose.yml` file that can be used to start an environment for local development. This environment includes (among their dependencies) a local Keycloak instance, a local FHIR Bridge service, and a local Demographics Service. Instructions in the README were updated accordingly.